### PR TITLE
Amend Chat tile to make tile labels consistent

### DIFF
--- a/apps/chat/tile/tile.js
+++ b/apps/chat/tile/tile.js
@@ -73,11 +73,7 @@ export default class ChatTile extends Component {
     return (
       <div className="w-100 h-100 relative" style={{ background: '#1a1a1a' }}>
         <a className="w-100 h-100 db pa2 no-underline" href="/~chat">
-          <p className="gray" style={{
-            fontWeight: 'bold',
-            fontSize: 14,
-            lineHeight: '24px'
-          }}>Chat</p>
+          <p className="gray label-regular b absolute" style={{left: 8, top: 4}}>Chat</p>
            <img
              className="absolute"
              style={{ left: 68, top: 65 }}


### PR DESCRIPTION
I'm doing testing for `create-modulo-app` and based a boilerplate tile off Chat's tile styling — but the label is less than even with Publish's:

![image](https://user-images.githubusercontent.com/20846414/61236232-53cdce00-a6ec-11e9-9612-7af7789f7638.png)

I noticed the styling between the two tiles is inconsistent. I asked @ixv for a quick assessment and we picked Publish's tile label styling as the de facto codifier for future boilerplate applications. 

This PR ports Publish's tile label styling to Chat's tile.